### PR TITLE
fix sql scripts

### DIFF
--- a/administrator/components/com_booking/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_booking/sql/install.mysql.utf8.sql
@@ -7,8 +7,6 @@ DROP TABLE IF EXISTS `speleo_formule_date`;
 CREATE TABLE `speleo_formule` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`sys_name` VARCHAR(255) NOT NULL,
-	`short_description` VARCHAR(255) NOT NULL,
-	`long_description` VARCHAR(255) NOT NULL,
 	`price` float(5) NOT NULL,
 	`min_person_allowed` INT(11) NOT NULL,
 	`max_person_allowed` INT(11) NOT NULL,

--- a/administrator/components/com_booking/sql/install.mysql.utf8.sql
+++ b/administrator/components/com_booking/sql/install.mysql.utf8.sql
@@ -1,9 +1,43 @@
 DROP TABLE IF EXISTS `speleo_booking`;
+DROP TABLE IF EXISTS `speleo_formule_period`;
 DROP TABLE IF EXISTS `speleo_formule`;
 DROP TABLE IF EXISTS `speleo_period`;
-DROP TABLE IF EXISTS `speleo_formule_period`;
 DROP TABLE IF EXISTS `speleo_formule_date`;
 
+CREATE TABLE `speleo_formule` (
+	`id` INT(11) NOT NULL AUTO_INCREMENT,
+	`sys_name` VARCHAR(255) NOT NULL,
+	`short_description` VARCHAR(255) NOT NULL,
+	`long_description` VARCHAR(255) NOT NULL,
+	`price` float(5) NOT NULL,
+	`min_person_allowed` INT(11) NOT NULL,
+	`max_person_allowed` INT(11) NOT NULL,
+	`google_place` VARCHAR(255) DEFAULT NULL,
+	`lat` VARCHAR(255) DEFAULT NULL,
+	`lng` VARCHAR(255) DEFAULT NULL,
+	`is_published` INT(11) DEFAULT 1,
+	`order` INT(11) DEFAULT 0,
+	`cdate` DATETIME NOT NULL DEFAULT NOW(),
+	`udate` DATETIME NOT NULL DEFAULT NOW(),
+	`difficulty` INT(11) NOT NULL DEFAULT 1,
+	PRIMARY KEY (`id`)
+)
+	ENGINE =InnoDB
+	AUTO_INCREMENT =0
+	DEFAULT CHARSET =utf8;
+
+CREATE TABLE `speleo_period` (
+	`id` INT(11) NOT NULL AUTO_INCREMENT,
+	`sys_name` VARCHAR(255) NOT NULL,
+	`hour` VARCHAR(255) DEFAULT NULL,
+	`cdate` DATETIME NOT NULL DEFAULT NOW(),
+	`udate` DATETIME NOT NULL DEFAULT NOW(),
+	PRIMARY KEY (`id`)
+)
+	ENGINE =InnoDB
+	AUTO_INCREMENT =0
+	DEFAULT CHARSET =utf8;
+	
 CREATE TABLE `speleo_booking` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
 	`formule_id` INT(11) NOT NULL,
@@ -23,42 +57,11 @@ CREATE TABLE `speleo_booking` (
 	`zip_code` VARCHAR(255) DEFAULT NULL,
 	`country` VARCHAR(255) DEFAULT NULL,
 	`encrypt` VARCHAR(255) NOT NULL,
-	`cdate` DATETIME NOT NULL DEFAULT 0,
-	`udate` DATETIME NOT NULL DEFAULT 0,
+	`cdate` DATETIME NOT NULL DEFAULT NOW(),
+	`udate` DATETIME NOT NULL DEFAULT NOW(),
 	PRIMARY KEY (`id`),
 	FOREIGN KEY (`formule_id`) REFERENCES speleo_formule(id),
 	FOREIGN KEY (`period_id`) REFERENCES speleo_period(id)
-)
-	ENGINE =InnoDB
-	AUTO_INCREMENT =0
-	DEFAULT CHARSET =utf8;
-
-CREATE TABLE `speleo_formule` (
-	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`sys_name` VARCHAR(255) NOT NULL,
-	`price` float(5) NOT NULL,
-	`min_person_allowed` INT(11) NOT NULL,
-	`max_person_allowed` INT(11) NOT NULL,
-	`google_place` VARCHAR(255) DEFAULT NULL,
-	`lat` VARCHAR(255) DEFAULT NULL,
-	`lng` VARCHAR(255) DEFAULT NULL,
-	`is_published` INT(11) DEFAULT 1,
-	`order` INT(11) DEFAULT 0,
-	`cdate` DATETIME NOT NULL DEFAULT 0,
-	`udate` DATETIME NOT NULL DEFAULT 0,
-	PRIMARY KEY (`id`)
-)
-	ENGINE =InnoDB
-	AUTO_INCREMENT =0
-	DEFAULT CHARSET =utf8;
-
-CREATE TABLE `speleo_period` (
-	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`sys_name` VARCHAR(255) NOT NULL,
-	`hour` VARCHAR(255) DEFAULT NULL,
-	`cdate` DATETIME NOT NULL DEFAULT 0,
-	`udate` DATETIME NOT NULL DEFAULT 0,
-	PRIMARY KEY (`id`)
 )
 	ENGINE =InnoDB
 	AUTO_INCREMENT =0
@@ -99,4 +102,4 @@ CREATE TABLE `speleo_formule_date` (
 	AUTO_INCREMENT =0
 	DEFAULT CHARSET =utf8;
 
-	INSERT INTO `speleo_extensions` VALUES (805,0,'Booking','component','com_booking','',1,1,0,0,'{\"name\":\"Booking\",\"type\":\"component\",\"creationDate\":\"December 2017\",\"author\":\"Raphael Colboc\",\"copyright\":\"Copyright Info\",\"authorEmail\":\"racol@smile.fr\",\"authorUrl\":\"\",\"version\":\"0.0.1\",\"description\":\"\",\"group\":\"\",\"filename\":\"booking\"}','{}','','',0,'0000-00-00 00:00:00',0,0);
+INSERT INTO `speleo_extensions` VALUES (805,0,'Booking','component','com_booking','',1,1,0,0,'{\"name\":\"Booking\",\"type\":\"component\",\"creationDate\":\"December 2017\",\"author\":\"Raphael Colboc\",\"copyright\":\"Copyright Info\",\"authorEmail\":\"racol@smile.fr\",\"authorUrl\":\"\",\"version\":\"0.0.1\",\"description\":\"\",\"group\":\"\",\"filename\":\"booking\"}','{}','','',0,NOW(),0,0);

--- a/administrator/components/com_booking/sql/uninstall.mysql.utf8.sql
+++ b/administrator/components/com_booking/sql/uninstall.mysql.utf8.sql
@@ -1,7 +1,7 @@
 DROP TABLE IF EXISTS `speleo_booking`;
+DROP TABLE IF EXISTS `speleo_formule_period`;
 DROP TABLE IF EXISTS `speleo_formule`;
 DROP TABLE IF EXISTS `speleo_period`;
-DROP TABLE IF EXISTS `speleo_formule_period`;
 DROP TABLE IF EXISTS `speleo_booking_localized`;
 DROP TABLE IF EXISTS `speleo_formule_date`;
 DELETE FROM speleo_extensions WHERE element = "com_booking";


### PR DESCRIPTION
Corrections suivantes : 
- problèmes dans l'ordre de délétion des tables (contraintes de clés étrangères)
- valeurs par défault de certaines collones
- ajouts des champs short/long_description dans la table speleo_formule